### PR TITLE
Update debug to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "puppeteer": ">=0.12.0"
   },
   "dependencies": {
-    "debug": "^3.1.0",
+    "debug": "^4.0.1",
     "lightning-pool": "^2.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,6 +2614,12 @@ debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.0.1.tgz#f9bb36d439b8d1f0dd52d8fb6b46e4ebb8c1cd5b"
+  dependencies:
+    ms "^2.1.1"
+
 decamelize-keys@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"


### PR DESCRIPTION
## Version **4.0.1** of **debug** was just published.

* Package: [repository](https://github.com/visionmedia/debug.git), [npm](https://www.npmjs.com/package/debug)
* Current Version: 3.1.0
* Dev: false
* [compare 3.1.0 to 4.0.1 diffs](https://github.com/visionmedia/debug/compare/3.1.0...4.0.1)

The version(`4.0.1`) is **not covered** by your current version range(`^3.1.0`).

Release note is not available


----------------------------------------

Powered by [hothouse](https://github.com/Leko/hothouse) :honeybee: